### PR TITLE
Use socket=fallback-x11 instead of x11

### DIFF
--- a/org.gnome.Firmware.json
+++ b/org.gnome.Firmware.json
@@ -7,7 +7,7 @@
   "finish-args": [
     "--share=ipc",
     "--socket=wayland",
-    "--socket=x11",
+    "--socket=fallback-x11",
     "--share=network",
     "--system-talk-name=org.freedesktop.fwupd"
   ],


### PR DESCRIPTION
This grants a sandbox hole for x11 only when Wayland is not available. This is known to work well for gtk3 apps.